### PR TITLE
Incorrect Type in Light URL

### DIFF
--- a/queryBuilder.php
+++ b/queryBuilder.php
@@ -74,13 +74,13 @@ $(function(){
 				$('#command_on_2').html(roomName + " TCP light ON");
 				$('#command_on_3').html(roomName + " light on");
 				$('#command_on_response').html("Turning " + roomName + " light ON");
-				$('#command_on_url').html( externalAddr + ( (externalPort != 80 || externalPort != 443) ?  ':' + externalPort : '' ) + '/api.php?fx=toggle&type=room&uid=' + id + '&val=1' + ( requireExtPass == 1 ? '&password=' + externalPass : '')  );
+				$('#command_on_url').html( externalAddr + ( (externalPort != 80 || externalPort != 443) ?  ':' + externalPort : '' ) + '/api.php?fx=toggle&type=device&uid=' + id + '&val=1' + ( requireExtPass == 1 ? '&password=' + externalPass : '')  );
 				
 				$('#command_off_1').html("TCP " +  roomName + " light off");
 				$('#command_off_2').html(roomName + " TCP Light off");
 				$('#command_off_3').html(roomName + " light off");
 				$('#command_off_response').html("Turning off " + roomName + " light");
-				$('#command_off_url').html( externalAddr + ( (externalPort != 80 || externalPort != 443) ?  ':' + externalPort : '' ) + '/api.php?fx=toggle&type=room&uid=' + id + '&val=0' + ( requireExtPass == 1 ? '&password=' + externalPass : '') );
+				$('#command_off_url').html( externalAddr + ( (externalPort != 80 || externalPort != 443) ?  ':' + externalPort : '' ) + '/api.php?fx=toggle&type=device&uid=' + id + '&val=0' + ( requireExtPass == 1 ? '&password=' + externalPass : '') );
 				
 				$('#command_dim_1').html("TCP " +  roomName + " light to # % brightness");
 				$('#command_dim_2').html(roomName + " TCP light brightness # %");


### PR DESCRIPTION
The bulb/light url generated had room specified as the type rather than device for the off and on commands